### PR TITLE
Use cdxj sub-directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ RUN gem install bundler
 
 # create the directory where WARC data and CDX indexes live
 RUN mkdir -p /web-archiving-stacks/data/collections/
-RUN mkdir /web-archiving-stacks/data/indexes/
+RUN mkdir -p /web-archiving-stacks/data/indexes/cdxj
 
 # add some WARC and CDXJ data for testing
 ADD ./test-data/apod.warc.gz /web-archiving-stacks/data/collections/apod.warc.gz
-ADD ./test-data/apod.cdxj /web-archiving-stacks/data/indexes/apod.cdxj
+ADD ./test-data/apod.cdxj /web-archiving-stacks/data/indexes/cdxj/apod.cdxj
 ADD ./test-data/stanford.warc.gz /web-archiving-stacks/data/collections/stanford.warc.gz
-ADD ./test-data/stanford.cdxj /web-archiving-stacks/data/indexes/stanford.cdxj
+ADD ./test-data/stanford.cdxj /web-archiving-stacks/data/indexes/cdxj/stanford.cdxj
 
 # add our code
 WORKDIR /home/was/swap/current/

--- a/pywb/config.yaml
+++ b/pywb/config.yaml
@@ -1,4 +1,4 @@
 collections:
   was:
-    index_paths: /web-archiving-stacks/data/indexes/
+    index_paths: /web-archiving-stacks/data/indexes/cdxj/
     archive_paths: /web-archiving-stacks/data/collections/


### PR DESCRIPTION
The qa, stage and prod environments have a NFS share where the indexes
live named /web-archiving-stacks/data/indexes/cdxj/ but our
configuration was set up to look for them in
/web-archiving-stacks/data/indexes/ This commit updates the config to
look for them in the right place (also in development Docker setup).

Fixes #30
