### PR TITLE
Path index configuration

### DIFF
--- a/pywb/config.yaml
+++ b/pywb/config.yaml
@@ -1,4 +1,7 @@
 collections:
   was:
     index_paths: /web-archiving-stacks/data/indexes/cdxj/
-    archive_paths: /web-archiving-stacks/data/collections/
+    archive_paths: 
+      - /web-archiving-stacks/data/indexes/path/path.txt
+      - /web-archiving-stacks/data/collections/
+


### PR DESCRIPTION
This change is needed to tell pywb where to look for the individual WARC files that it finds in the CDXJ index files. The `/web-archiving-stacks/data/indexes/path/path.txt` file maps the filename to the absolute path where the file lives.

Fixes #29
