### PR TITLE
Config bundler

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler/setup'
+
 $LOAD_PATH.unshift File.expand_path(File.join(__dir__, '..', 'lib'))
 
 require 'indexer'


### PR DESCRIPTION
This change is needed in our qa, stage and prod environments to be able to load bundle installed gems. Without it you'll see something like:

```
was@was-pywb-stage:~/swap/current$ bin/index.rb
<internal:/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- parallel (LoadError)
	from <internal:/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /home/was/swap/releases/20220615205045/lib/indexer.rb:8:in `<top (required)>'
	from <internal:/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /home/was/swap/releases/20220615205045/config/boot.rb:5:in `<top (required)>'
	from <internal:/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from bin/index.rb:4:in `<main>'
```

It's not clear why this wasn't an issue when testing in `was-dev` but that environment will go away shortly and qa, stage and prod are what matters going forwards.
