### PR TITLE
Test ACLJ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ ADD ./test-data/apod.cdxj /web-archiving-stacks/data/indexes/cdxj/apod.cdxj
 ADD ./test-data/stanford.warc.gz /web-archiving-stacks/data/collections/stanford.warc.gz
 ADD ./test-data/stanford.cdxj /web-archiving-stacks/data/indexes/cdxj/stanford.cdxj
 
+# add the ALCJ file for testing
+ADD ./test-data/access.aclj /web-archiving-stacks/data/access.aclj
+
 # add our code
 WORKDIR /home/was/swap/current/
 ADD . /home/was/swap/current

--- a/pywb/config.yaml
+++ b/pywb/config.yaml
@@ -4,4 +4,5 @@ collections:
     archive_paths: 
       - /web-archiving-stacks/data/indexes/path/path-index.txt
       - /web-archiving-stacks/data/collections/
+    acl_paths: /web-archiving-stacks/data/access.aclj
 

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -31,4 +31,10 @@ describe 'Web' do
     expect(payload['url']).to eq('https://apod.nasa.gov/')
     expect(payload['mime']).to eq('text/html')
   end
+
+  it 'excludes content' do
+    url = URI('http://localhost:8080/was/20220510010324mp_/https://apod.nasa.gov/apod/lib/apsubmit2015.html')
+    resp = Net::HTTP.get_response(url)
+    expect(resp).to be_instance_of(Net::HTTPNotFound)
+  end
 end

--- a/test-data/access.aclj
+++ b/test-data/access.aclj
@@ -1,0 +1,1 @@
+gov,nasa,apod)/apod/lib/apsubmit2015.html - {"access": "exclude", "url": "https://apod.nasa.gov/apod/lib/apsubmit2015.html"}


### PR DESCRIPTION
Add a simple test that blocked content returns a 404 error message. This
mostly is here to make sure our pywb configuration file is referencing
the ACLJ file correctly, and that pywb continues to work as expected.

Closes #23
