### PR TITLE
Add SUL header and footer to the playback page

### DIFF
--- a/pywb/static/css/stanford-header.css
+++ b/pywb/static/css/stanford-header.css
@@ -36,3 +36,7 @@ body {
     }
   }
 }
+
+#_wb_frame_top_banner {
+  margin-top: 49px;
+}

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8;charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>{% block title %}{% endblock %}</title>
+
+  <!-- jquery and bootstrap dependencies query view -->
+  <link rel="stylesheet" href="{{ static_prefix }}/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="{{ static_prefix }}/css/font-awesome.min.css">
+  <link rel="stylesheet" href="{{ static_prefix }}/css/base.css">
+
+  <script src="{{ static_prefix }}/js/jquery-latest.min.js"></script>
+  <script src="{{ static_prefix }}/js/bootstrap.min.js"></script>
+  <script src='{{ static_prefix }}/wb_frame.js'> </script>
+
+  {% block head %}
+  {% include 'head.html' ignore missing %}
+  {% endblock %}
+
+  {% autoescape false %}
+
+  {{ banner_html }}
+
+</head>
+
+<body style="margin: 0px; padding: 0px;">
+  <div id="su-wrap">
+    <div id="su-content">
+      {% block header %}
+      {% include 'header.html' ignore missing %}
+      {% endblock %}
+
+      <section>
+        <div id="wb_iframe_div">
+          <iframe id="replay_iframe" frameborder="0" seamless="seamless" scrolling="yes" class="wb_iframe"
+            allow="autoplay; fullscreen"></iframe>
+        </div>
+        <script>
+          var cframe = new ContentFrame({
+            "url": "{{ url }}" + window.location.hash,
+            "prefix": "{{ wb_prefix }}",
+            "request_ts": "{{ wb_url.timestamp }}",
+            "iframe": "#replay_iframe"
+          });
+
+        </script>
+      </section>
+    </div>
+  </div>
+
+  {% block footer %}
+  {% include 'footer.html' ignore missing %}
+  {% endblock footer %}
+</body>
+
+</html>
+{% endautoescape %}


### PR DESCRIPTION
Closes #65 by adding the header and footer from the homepage to the framed playback page.
![Screen Shot 2022-06-23 at 2 02 14 PM](https://user-images.githubusercontent.com/2294288/175399357-ce144eb8-8a99-449a-ba4e-f57a56508a81.png)

