### PR TITLE
Tell pip to upgrade Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN bundle install
 
 # Python depdendencies for pywb
 WORKDIR /home/was/swap/current/pywb
-RUN pip3 install -r requirements.txt
+RUN pip3 install --upgrade --requirement requirements.txt
 
 # run!
 CMD ["uwsgi", "uwsgi.ini"]

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,7 +76,7 @@ namespace :pip do
   task :install do
     on roles(:app) do
       within "#{current_path}/pywb" do
-        execute :pip3, :install, '-r requirements.txt'
+        execute :pip3, :install, '--upgrade', '--requirement requirements.txt'
       end
     end
   end


### PR DESCRIPTION
Since we are using our deployment to upgrade pywb dependencies #43 we
need to be sure to pass the `--upgrade` option. Otherwise when asked to
install something that's already installed it will skip it.

This change will get the latest cdxj-indexer in our various environments
when we deploy.

Fixes #26
