### PR TITLE
Add previous and next capture links to playback header

### DIFF
--- a/pywb/static/css/playback.css
+++ b/pywb/static/css/playback.css
@@ -1,0 +1,7 @@
+.prev_capture {
+  margin: 0 15px 0 15px;
+}
+
+.next_capture {
+  margin: 0 15px 0 15px;
+}

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="{{ static_prefix }}/css/bootstrap.min.css" />
   <link rel="stylesheet" href="{{ static_prefix }}/css/font-awesome.min.css">
   <link rel="stylesheet" href="{{ static_prefix }}/css/base.css">
+  <link rel="stylesheet" href="{{ static_prefix }}/css/playback.css">
 
   <script src="{{ static_prefix }}/js/jquery-latest.min.js"></script>
   <script src="{{ static_prefix }}/js/bootstrap.min.js"></script>
@@ -51,6 +52,57 @@
     </div>
   </div>
 </body>
+
+<script>
+  window.onload = function () {
+    var titleElement = document.getElementById('_wb_ancillary_links')
+    var prevSpan = document.createElement("span")
+    prevSpan.setAttribute("class", "prev_capture")
+
+    var prevLink = document.createElement("a")
+    prevLink.setAttribute("id", "prev_capture_link")
+    prevLink.innerHTML = "< Previous Capture"
+    prevSpan.appendChild(prevLink)
+
+    var nextSpan = document.createElement("span")
+    nextSpan.setAttribute("class", "next_capture")
+    var nextLink = document.createElement("a")
+    nextLink.setAttribute("id", "next_capture_link")
+    nextLink.innerHTML = "Next Capture >"
+    nextSpan.appendChild(nextLink)
+
+    titleElement.insertBefore(prevSpan, titleElement.firstChild)
+    titleElement.appendChild(nextSpan)
+
+    var request = new XMLHttpRequest()
+    request.open('GET', '{{ wb_prefix }}cdx?url={{ url }}&output=json')
+    request.onload = function () {
+      var data = this.response.trim().split(/\r?\n/)
+      var currentTimestamp = '{{ wb_url.timestamp }}'
+      data.forEach(function (crawl, index, data) {
+        crawl = JSON.parse(crawl)
+        if (crawl.timestamp == currentTimestamp) {
+          // Get Previous Capture Link
+          if (index > 0) {
+            previousCapture = JSON.parse(data[index - 1])
+            prevLink.setAttribute("href", "{{ wb_prefix }}" + previousCapture.timestamp + "/{{ url }}")
+          } else {
+            prevLink.style.display = "none"
+          }
+
+          // Get Next Capture Link
+          if (index < data.length - 1) {
+            nextCapture = JSON.parse(data[index + 1])
+            nextLink.setAttribute("href", "{{ wb_prefix }}" + nextCapture.timestamp + "/{{ url }}")
+          } else {
+            nextLink.style.display = "none"
+          }
+        }
+      })
+    }
+    request.send()
+  };
+</script>
 
 </html>
 {% endautoescape %}


### PR DESCRIPTION
Closes #52 

When viewing the first available crawl, the `previous capture` link is not available:
<img width="534" alt="Screen Shot 2022-07-07 at 1 36 41 PM" src="https://user-images.githubusercontent.com/2294288/177867012-875f2b26-62fa-4aff-a4e9-e740efa5376a.png">

When viewing a crawl with both prior and future crawls both links are available:
<img width="548" alt="Screen Shot 2022-07-07 at 1 36 46 PM" src="https://user-images.githubusercontent.com/2294288/177867035-10b69c56-2a2e-4f8f-afae-06f15a9aab64.png">

When viewing the last crawl, the `next capture` link is not available:
<img width="447" alt="Screen Shot 2022-07-07 at 1 36 53 PM" src="https://user-images.githubusercontent.com/2294288/177867058-2e8c5314-ddeb-4d30-bf33-552d64adc1cd.png">

