### PR TITLE
Fixes logo link in replay banner

### DIFF
--- a/pywb/templates/banner.html
+++ b/pywb/templates/banner.html
@@ -14,7 +14,9 @@ window.banner_info = {
     logoAlt: decodeURIComponent("{{ _Q('Logo') }}"),
     logoImg: "{{ static_prefix}}/images/StanfordLibraries-logo-whitetext.svg",
 
-    locale: "{{ env.pywb_lang | default('en') }}",
+    /* locale gets appended to the logoImg link. 
+    Setting to empty string since we are not using locales and it interferes with redirects to /was */
+    locale: "",
     curr_locale: "{{ env.pywb_lang }}",
     locales: {{ locales }},
     locale_prefixes: {{ get_locale_prefixes() | tojson }},


### PR DESCRIPTION
`default_banner.js` adds the locale to the replay header logo, which we added recently. It ends up creating the link `https://swap.stanford.edu/en` which gets redirected to `https://swap.stanford.edu/was/en` and shows an error. While we could change the redirects, we are not using locale(s) in the replay UI so can safely edit the parameter that gets added to window.banner_info. 