### PR TITLE
Hook into JenkinsCI to update Python dependencies

### DIFF
--- a/.autoupdate/preupdate
+++ b/.autoupdate/preupdate
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script is called by our weekly dependency update job in Jenkins, before updating Ruby and other deps
+cd pywb/
+
+# Without these ENV changes, python gets confused and tries to use latin1
+# encodings which breaks the poetry update below
+export LANG=en_US.UTF-8
+export LC_COLLATE=C.UTF-8
+
+pip3 install --upgrade --requirement requirements.txt > was-pywb.txt &&
+    ~/.local/bin/poetry update -n --no-ansi >> was-pywb.txt &&
+    git add poetry.lock &&
+    git commit -m "Update Python dependencies"
+
+retVal=$?
+
+if [ $retVal -ne 0 ]; then
+    echo "ERROR UPDATING PYTHON (was-pywb)"
+    cat was-pywb.txt
+fi
+
+cd ..


### PR DESCRIPTION
## Why was this change made? 🤔

This is what adds a Python deps commit to the weekly updates.

## How was this change tested? 🤨

I ran JenkinsCI a bunch of times. It now runs the expected commands without errors.
