### PR TITLE
Missing directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note: Wildcard copies are not currently supported by docker, so the above comman
 Then you will need to update the index by running `cdx-indexer`:
 
 ```
-$ docker compose exec pywb cdxj-indexer /web-archiving-stacks/data/collections/ --output /web-archiving-stacks/data/indexes/index.cdxj --sort --post-append
+$ docker compose exec pywb cdxj-indexer /web-archiving-stacks/data/collections/ --output /web-archiving-stacks/data/indexes/cdxj/index.cdxj --sort --post-append
 ```
 
 ### Generating WARC data


### PR DESCRIPTION
## Why was this change made? 🤔

CDXJ index files need to be written to the cdxj subdirectory, or else pywb won't notice them.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other services), 
***run the web archive accession [integration test](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
