### PR TITLE
Pin pywb to 2.6.*

### DIFF
--- a/pywb/pyproject.toml
+++ b/pywb/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache 2.0"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pywb = "^2.6.7"
+pywb = "~2.6.7"
 uWSGI = "^2.0.20"
 cdxj-indexer = "^1.4.5"
 


### PR DESCRIPTION
## Why was this change made? 🤔

Pywb 2.7 will bring breaking changes when it is released, so we want only patch updates of pywb 2.6 until we're ready to upgrade.

## How was this change tested? 🤨
CI

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other services), 
***run the web archive accession [integration test](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
