### PR TITLE
Google Analytics 4

### DIFF
--- a/pywb/templates/banner.html
+++ b/pywb/templates/banner.html
@@ -1,0 +1,64 @@
+{% if not env.pywb_proxy_magic or config.proxy.enable_banner | default(true) %}
+{% autoescape false %}
+
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-S1G1JW9N91"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-S1G1JW9N91');
+
+  /*
+  Add a Google Analytics event to track the hostname for the archived page that
+  was viewed. This is useful for seeing what archived content is being viewed in
+  SWAP.
+  
+  For example when a user views this URL in their browser:
+  
+  https://swap.stanford.edu/was/20220611113312mp_/https://www.stanford.edu/research/
+  
+  This would result in a "host-view" event being sent to Google Analytics with "host" 
+  set to "stanford.edu". Note the stripping of leading "www".
+  */
+
+  try {
+    const archivedUrl = new URL("{{ url }}");
+    const archivedHost = archivedUrl.hostname.replace('www.', '');
+    gtag('event', 'archive-view', {'host': archivedHost});
+  } catch (error) {
+    console.log(`Can't send Google Analytics host-view event: ${error}`);
+  }
+
+</script>
+
+<script>
+window.banner_info = {
+    is_gmt: true,
+
+    liveMsg: decodeURIComponent("{{ _Q('Live on') }}"),
+
+    calendarAlt: decodeURIComponent("{{ _Q('Calendar icon') }}"),
+    calendarLabel: decodeURIComponent("{{ _Q('View All Captures') }}"),
+    choiceLabel: decodeURIComponent("{{ _Q('Language:') }}"),
+    loadingLabel: decodeURIComponent("{{ _Q('Loading...') }}"),
+    logoAlt: decodeURIComponent("{{ _Q('Logo') }}"),
+
+    locale: "{{ env.pywb_lang | default('en') }}",
+    curr_locale: "{{ env.pywb_lang }}",
+    locales: {{ locales }},
+    locale_prefixes: {{ get_locale_prefixes() | tojson }},
+    prefix: "{{ wb_prefix }}",
+    staticPrefix: "{{ static_prefix }}",
+
+    logoImg: "{{ ui.logo }}"
+};
+</script>
+<script src="{{ static_prefix }}/loading-spinner/loading-spinner.js"></script>
+<script src="{{ static_prefix }}/vue/vueui.js"></script>
+<link rel="stylesheet" href='{{ static_prefix }}/vue_banner.css'/>
+
+{% include 'bootstrap_jquery.html' ignore missing %}
+
+{% endautoescape %}
+{% endif %}

--- a/pywb/templates/head.html
+++ b/pywb/templates/head.html
@@ -6,14 +6,11 @@
 <link rel="stylesheet" href="{{ static_prefix }}/css/stanford-footer.css" />
 <link rel="shortcut icon" href="{{ static_prefix }}/favicon.ico" />
 
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-S1G1JW9N91"></script>
 <script>
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-  })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', 'UA-7219229-29', 'auto');
-  ga('send', 'pageview');
+  gtag('config', 'G-S1G1JW9N91');
 </script>


### PR DESCRIPTION
## Why was this change made? 🤔

Add the new Google Analytics 4 embed code. pywb has two header templates, one that is used for regular pages (head.html) and one that is used when viewing archived content (banner.html).

An experimental event is also sent with the hostname of the archived website to see if it is helpful in tracking what web content is being viewed in SWAP.

Refs #158

(will close when it is verified to be working in Google Analytics)

## How was this change tested? 🤨

Testing locally in Docker. Unfortunately we won't be able to see whether it is working until it is deployed to swap.stanford.edu.

⚡ ⚠ If this change has cross service impact (including writing to shared file systems or interacting with other services), 
***run the web archive accession [integration test](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
