### PR TITLE
Fix Stanford Libraries footer links

### DIFF
--- a/pywb/templates/footer.html
+++ b/pywb/templates/footer.html
@@ -8,10 +8,9 @@
       </div>
       <div id="sul-footer-links" class="span2">
         <ul>
-          <li><a href="https://library.stanford.edu/hours">Hours &amp; locations</a></li>
-          <li><a href="https://library.stanford.edu/myaccount">My Account</a></li>
-          <li><a href="https://library.stanford.edu/ask">Ask us</a></li>
-          <li><a href="https://library.stanford.edu/opt-out">Opt out of analytics</a></li>
+          <li><a href="https://library-hours.stanford.edu/">Hours &amp; locations</a></li>
+          <li><a href="https://mylibrary.stanford.edu/">My Account</a></li>
+          <li><a href="https://library.stanford.edu/contact-us">Ask us</a></li>
           <li><a href="https://library-status.stanford.edu/">System status</a></li>
         </ul>
       </div>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #204

This commit changes links in the SUL footer now that the new Stanford Libraries website has gone live after undergoing a thorough rebuild.

# How was this change tested? 🤨

CI

# Does your change introduce accessibility violations? 🩺

No.
