### PR TITLE
Enable website stats gathering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,6 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
-    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
@@ -107,6 +105,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/pywb/templates/banner.html
+++ b/pywb/templates/banner.html
@@ -8,6 +8,31 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', 'G-S1G1JW9N91');
+
+  /*
+  Add a Google Analytics event to track the hostname for the archived page that
+  is being viewed. This is useful for seeing what archived content is being viewed in
+  SWAP.
+  
+  For example when a user views this URL in their browser:
+  
+  https://swap.stanford.edu/was/20220611113312/https://www.stanford.edu/research/
+  
+  This would result in a "host-view" event being sent to Google Analytics with "host" 
+  set to "stanford.edu". Note the stripping of leading "www".
+  */
+
+  const match = window.location.pathname.match(/\d+\/(https?:\/\/.*)/);
+  if (match !== null) {
+    // guard against an invalid URL exception when constructing the URL
+    try {
+      const url = new URL(match[1]);
+      const archivedHost = url.hostname.replace('www.', '');
+      gtag('event', 'archive-view', {'host': archivedHost});
+    } catch(error) {
+      console.log(`Can't send Google Analytics host-view event: ${error}`);
+    }
+  }
 </script>
 
 <script>


### PR DESCRIPTION
# Why was this change made? 🤔
 
It has been helpful to collect statistics about what web content is being viewed in SWAP. To do that we need to determine what URL is being viewed in the archive, extract the hostname from that, and then send it along to Google Analytics as a custom event.

Previously we were using the Jinja2 `url` variable supplied by pywb. But we can't (currently) interpolate that into JavaScript without introducing a potential XSS vulnerability. This solution is to simply look for the URL that's embedded in the `window.location.pathname` and use that instead.

# How was this change tested? 🤨

Deploy to stage and seeing that the GA event was sent with the correct hostname.
